### PR TITLE
edk2-libc: Add manual dispatch for the Python UEFI build actions

### DIFF
--- a/.github/workflows/build-python-uefi-gcc.yaml
+++ b/.github/workflows/build-python-uefi-gcc.yaml
@@ -1,12 +1,12 @@
 # GitHub actions workflow to build python uefi using gcc
 #
-# Copyright (c) 2023-2024, Intel Corporation. All rights reserved.
+# Copyright (c) 2023-2025, Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
 name: Build Python Interpreter for UEFI with GCC
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/build-python-uefi-ia32-vs.yaml
+++ b/.github/workflows/build-python-uefi-ia32-vs.yaml
@@ -1,12 +1,12 @@
 # GitHub actions workflow to build python uefi in ia32 using VS2019
 #
-# Copyright (c) 2023-2024, Intel Corporation. All rights reserved.
+# Copyright (c) 2023-2025, Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
 name: Build Python Interpreter for UEFI in IA32 using VS2019
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/build-python-uefi-vs.yaml
+++ b/.github/workflows/build-python-uefi-vs.yaml
@@ -1,12 +1,12 @@
 # GitHub actions workflow to build python uefi using VS2019
 #
-# Copyright (c) 2023-2024, Intel Corporation. All rights reserved.
+# Copyright (c) 2023-2025, Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
 name: Build Python Interpreter for UEFI using VS2019
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/build-python-uefi-vs2022.yaml
+++ b/.github/workflows/build-python-uefi-vs2022.yaml
@@ -1,12 +1,12 @@
 # GitHub actions workflow to build python uefi using VS2022
 #
-# Copyright (c) 2023 - 2024, Intel Corporation. All rights reserved.
+# Copyright (c) 2023 - 2025, Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
 name: Build Python Interpreter for UEFI using VS2022
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:


### PR DESCRIPTION
REF: https://github.com/tianocore/edk2-libc/issues/89

The current build actions are setup to dispatch on push or pull requests. Since there is not much development activity happening on the Python UEFI, We are seeing that the build artifacts are getting expired after 90 days. Would like to add manual dispatch mechanism to trigger the build on need basis.

Closes #89